### PR TITLE
Updating to documentation to match code for closeOnStateChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ A service you can inject in your controller to show the Content Banner
   
     Number of milliseconds before the content banner automatically closes.  This option is disabled by default.  
 
-  - `{boolean=}` `cancelOnStateChange`
+  - `{boolean=}` `closeOnStateChange`
 
     Whether to cancel the content banner when navigating to a new state.  Default value is true.
 


### PR DESCRIPTION
Found a small bug in the documentation in which it was written that the option to avoid closing the banner on state change is cancelOnStateChange while in the code it has been added as closeOnStateChange
